### PR TITLE
Add focusable button and optional play label

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <body>
     <h1><code>lite-youtube</code> custom element</h1>
 
-    <lite-youtube videoid="ogfYd705cRs"></lite-youtube>
+    <lite-youtube videoid="ogfYd705cRs" playlabel="Play Video: Keynote (Google I/O '18)"></lite-youtube>
 
     <script src="./src/lite-yt-embed.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -12,10 +12,6 @@
     <lite-youtube videoid="ogfYd705cRs"></lite-youtube>
 
     <script src="./src/lite-yt-embed.js"></script>
-    <script>
-      // Register custom element
-      customElements.define('lite-youtube', LiteYTEmbed);
-    </script>
 
     <h3>View isolated demos:</h3>
     <ul>

--- a/index.html
+++ b/index.html
@@ -17,14 +17,11 @@
       customElements.define('lite-youtube', LiteYTEmbed);
     </script>
 
-
-
     <h3>View isolated demos:</h3>
     <ul>
       <li><a href="./variants/solo.html">lite-youtube-embed</a>
+      <li><a href="./variants/pe.html">lite-youtube-embed - progressively enhanced</a>
       <li><a href="./variants/yt.html">normal youtube embed</a>
     </ul>
-
-
   </body>
 </html>

--- a/now.json
+++ b/now.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -1,10 +1,8 @@
 lite-youtube {
-    width: 560px;
-    height: 315px;
     background-color: #000;
     position: relative;
-    contain: strict;
     display: block;
+    contain: content;
     background-position: center center;
     background-size: cover;
     cursor: pointer;
@@ -24,8 +22,25 @@ lite-youtube::before {
     width: 100%;
     transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
 }
+
+/* responsive iframe with a 16:9 aspect ratio
+    thanks https://css-tricks.com/responsive-iframes/
+*/
+lite-youtube::after {
+    content: "";
+    display: block;
+    padding-bottom: calc(100% / (16 / 9));
+}
+lite-youtube > iframe {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
 /* play button */
-lite-youtube .lty-playbtn {
+lite-youtube > .lty-playbtn {
     width: 70px;
     height: 46px;
     background-color: #212121;
@@ -34,20 +49,20 @@ lite-youtube .lty-playbtn {
     border-radius: 14%; /* TODO: Consider replacing this with YT's actual svg. Eh. */
     transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
 }
-lite-youtube:hover .lty-playbtn {
+lite-youtube:hover > .lty-playbtn {
     background-color: #f00;
     opacity: 1;
 }
 /* play button triangle */
-lite-youtube .lty-playbtn:before {
+lite-youtube > .lty-playbtn:before {
     content: '';
     border-style: solid;
     border-width: 11px 0 11px 19px;
     border-color: transparent transparent transparent #fff;
 }
 
-lite-youtube .lty-playbtn,
-lite-youtube .lty-playbtn:before {
+lite-youtube > .lty-playbtn,
+lite-youtube > .lty-playbtn:before {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -59,7 +74,7 @@ lite-youtube.lyt-activated {
     cursor: unset;
 }
 lite-youtube.lyt-activated::before,
-lite-youtube.lyt-activated .lty-playbtn {
+lite-youtube.lyt-activated > .lty-playbtn {
     opacity: 0;
     pointer-events: none;
 }

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -47,13 +47,18 @@ lite-youtube > .lty-playbtn {
     top: 50%;
     left: 50%;
     transform: translate3d(-50%, -50%, 0);
-    cursor: pointer;
+    cursor: inherit;
     background: none;
+    padding: 0;
+    display: block;
+    width: 68px;
+    height: 48px;
+    transition: opacity 0.2s cubic-bezier(0, 0, 0.2, 1);
 }
 
 lite-youtube .lty-playicon {
-    width: 68px;
-    height: 48px;
+    width: 100%;
+    height: 100%;
 }
 
 lite-youtube .lty-playicon-base {

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -43,21 +43,31 @@ lite-youtube > iframe {
 lite-youtube > .lty-playbtn {
     z-index: 1;
     border: 0;
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"%3E%3Cdefs/%3E%3Cpath fill="%23212121" fill-opacity=".8" d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" class="ytp-large-play-button-bg"/%3E%3Cpath fill="%23fff" d="M45 24L27 14v20"/%3E%3C/svg%3E');
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-color: transparent;
-    width: 68px;
-    height: 48px;
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate3d(-50%, -50%, 0);
     cursor: pointer;
+    background: none;
 }
 
-lite-youtube > .lty-playbtn:hover {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"%3E%3Cdefs/%3E%3Cpath fill="%23FF0000" d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" class="ytp-large-play-button-bg"/%3E%3Cpath fill="%23fff" d="M45 24L27 14v20"/%3E%3C/svg%3E');
+lite-youtube .lty-playicon {
+    width: 68px;
+    height: 48px;
+}
+
+lite-youtube .lty-playicon-base {
+    fill: #212121;
+    fill-opacity: 0.8;
+}
+
+lite-youtube .lty-playicon-play {
+    fill: #ffffff;
+}
+
+lite-youtube > .lty-playbtn:hover .lty-playicon-base {
+    fill: #ff0000;
+    fill-opacity: 1;
 }
 
 /* match styles of the original Youtube play button focus */

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -41,33 +41,29 @@ lite-youtube > iframe {
 
 /* play button */
 lite-youtube > .lty-playbtn {
-    width: 70px;
-    height: 46px;
-    background-color: #212121;
     z-index: 1;
-    opacity: 0.8;
-    border-radius: 14%; /* TODO: Consider replacing this with YT's actual svg. Eh. */
     border: 0;
-    transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
-}
-lite-youtube:hover > .lty-playbtn {
-    background-color: #f00;
-    opacity: 1;
-}
-/* play button triangle */
-lite-youtube > .lty-playbtn:before {
-    content: '';
-    border-style: solid;
-    border-width: 11px 0 11px 19px;
-    border-color: transparent transparent transparent #fff;
-}
-
-lite-youtube > .lty-playbtn,
-lite-youtube > .lty-playbtn:before {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"%3E%3Cdefs/%3E%3Cpath fill="%23212121" fill-opacity=".8" d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" class="ytp-large-play-button-bg"/%3E%3Cpath fill="%23fff" d="M45 24L27 14v20"/%3E%3C/svg%3E');
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-color: transparent;
+    width: 68px;
+    height: 48px;
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate3d(-50%, -50%, 0);
+    cursor: pointer;
+}
+
+lite-youtube > .lty-playbtn:hover {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"%3E%3Cdefs/%3E%3Cpath fill="%23FF0000" d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" class="ytp-large-play-button-bg"/%3E%3Cpath fill="%23fff" d="M45 24L27 14v20"/%3E%3C/svg%3E');
+}
+
+/* match styles of the original Youtube play button focus */
+lite-youtube > .lty-playbtn:focus {
+    outline: 0;
+    box-shadow: inset 0 0 0 2px rgba(27,127,204,.8);
 }
 
 /* Post-click styles */

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -47,6 +47,7 @@ lite-youtube > .lty-playbtn {
     z-index: 1;
     opacity: 0.8;
     border-radius: 14%; /* TODO: Consider replacing this with YT's actual svg. Eh. */
+    border: 0;
     transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
 }
 lite-youtube:hover > .lty-playbtn {
@@ -77,4 +78,5 @@ lite-youtube.lyt-activated::before,
 lite-youtube.lyt-activated > .lty-playbtn {
     opacity: 0;
     pointer-events: none;
+    outline: 0;
 }

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -14,9 +14,10 @@ class LiteYTEmbed extends HTMLElement {
     constructor() {
         super();
 
-        // Gotta encode the untrusted value
+        // Gotta encode the untrusted values
         // https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-2---attribute-escape-before-inserting-untrusted-data-into-html-common-attributes
         this.videoId = encodeURIComponent(this.getAttribute('videoid'));
+        this.playLabel = encodeURIComponent(this.getAttribute('playlabel'));
 
         /**
          * Lo, the youtube placeholder image!  (aka the thumbnail, poster image, etc)
@@ -43,9 +44,15 @@ class LiteYTEmbed extends HTMLElement {
     connectedCallback() {
         this.style.backgroundImage = `url("${this.posterUrl}")`;
 
-        const playBtn = document.createElement('div');
-        playBtn.classList.add('lty-playbtn');
-        this.append(playBtn);
+        let playBtn = this.querySelector('.lty-playbtn');
+
+        if (!playBtn) {
+            playBtn = document.createElement('button');
+            playBtn.type = 'button';
+            playBtn.title = decodeURIComponent(this.playLabel) || `Play Video: ${this.videoId}`
+            playBtn.classList.add('lty-playbtn');
+            this.append(playBtn);
+        }
 
         // On hover (or tap), warm up the TCP connections we're (likely) about to use.
         this.addEventListener('pointerover', LiteYTEmbed.warmConnections, {once: true});

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -17,7 +17,7 @@ class LiteYTEmbed extends HTMLElement {
         // Gotta encode the untrusted values
         // https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-2---attribute-escape-before-inserting-untrusted-data-into-html-common-attributes
         this.videoId = encodeURIComponent(this.getAttribute('videoid'));
-        this.playLabel = encodeURIComponent(this.getAttribute('playlabel'));
+        this.playLabel = this.getAttribute('playlabel') ? encodeURIComponent(this.getAttribute('playlabel')) : null;
 
         /**
          * Lo, the youtube placeholder image!  (aka the thumbnail, poster image, etc)
@@ -51,6 +51,14 @@ class LiteYTEmbed extends HTMLElement {
             playBtn.type = 'button';
             playBtn.title = this.playLabel ? decodeURIComponent(this.playLabel) : `Play Video: ${this.videoId}`;
             playBtn.classList.add('lty-playbtn');
+            const iconHTML = `
+                <svg class="lty-playicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48">
+                    <defs/>
+                    <path class="lty-playicon-base" d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" class="ytp-large-play-button-bg"/>
+                    <path class="lty-playicon-play" d="M45 24L27 14v20"/>
+                </svg>
+            `;
+            playBtn.insertAdjacentHTML('afterbegin', iconHTML);
             this.append(playBtn);
         }
 

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -99,12 +99,10 @@ class LiteYTEmbed extends HTMLElement {
     }
 
     addIframe(){
-        // https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-2---attribute-escape-before-inserting-untrusted-data-into-html-common-attributes
-        const escapedVideoId = encodeURIComponent(this.videoId);
         const iframeHTML = `
 <iframe width="560" height="315" frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen
-  src="https://www.youtube.com/embed/${escapedVideoId}?autoplay=1"
+  src="https://www.youtube.com/embed/${this.videoId}?autoplay=1"
 ></iframe>`;
         this.insertAdjacentHTML('beforeend', iframeHTML);
         this.classList.add('lyt-activated');

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -110,3 +110,5 @@ class LiteYTEmbed extends HTMLElement {
         this.classList.add('lyt-activated');
     }
 }
+// Register custome element
+customElements.define('lite-youtube', LiteYTEmbed);

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -49,7 +49,7 @@ class LiteYTEmbed extends HTMLElement {
         if (!playBtn) {
             playBtn = document.createElement('button');
             playBtn.type = 'button';
-            playBtn.title = decodeURIComponent(this.playLabel) || `Play Video: ${this.videoId}`
+            playBtn.title = this.playLabel ? decodeURIComponent(this.playLabel) : `Play Video: ${this.videoId}`;
             playBtn.classList.add('lty-playbtn');
             this.append(playBtn);
         }

--- a/variants/pe.html
+++ b/variants/pe.html
@@ -12,7 +12,7 @@
 <p id="done">...</p>
 
 <lite-youtube videoid="ogfYd705cRs" style="background-image: url('https://i.ytimg.com/vi/ogfYd705cRs/hqdefault.jpg');">
-	<button type="button" class="lty-playbtn" title="Keynote (Google I/O '18)"></button>
+	<button type="button" class="lty-playbtn" title="Play Video: Keynote (Google I/O '18)"></button>
 </lite-youtube>
 
 <script>

--- a/variants/pe.html
+++ b/variants/pe.html
@@ -12,7 +12,13 @@
 <p id="done">...</p>
 
 <lite-youtube videoid="ogfYd705cRs" style="background-image: url('https://i.ytimg.com/vi/ogfYd705cRs/hqdefault.jpg');">
-	<button type="button" class="lty-playbtn" title="Play Video: Keynote (Google I/O '18)"></button>
+  <button type="button" class="lty-playbtn" title="Play Video: Keynote (Google I/O '18)">
+    <svg class="lty-playicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48">
+      <defs/>
+      <path class="lty-playicon-base" d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" class="ytp-large-play-button-bg"/>
+      <path class="lty-playicon-play" d="M45 24L27 14v20"/>
+    </svg>
+  </button>
 </lite-youtube>
 
 <script>

--- a/variants/pe.html
+++ b/variants/pe.html
@@ -22,10 +22,7 @@ setTimeout(_ => {
   elem.src = '../src/lite-yt-embed.js';
   document.head.append(elem);
 
-  elem.onload = _ => {
-    customElements.define('lite-youtube', LiteYTEmbed);
-    document.querySelector('#done').textContent = 'Script complete.'
-  };
+  document.querySelector('#done').textContent = 'Script complete.'
 }, 2000);
 </script>
 

--- a/variants/pe.html
+++ b/variants/pe.html
@@ -12,7 +12,7 @@
 <p id="done">...</p>
 
 <lite-youtube videoid="ogfYd705cRs" style="background-image: url('https://i.ytimg.com/vi/ogfYd705cRs/hqdefault.jpg');">
-	<button class="lty-playbtn" title="Keynote (Google I/O '18)"></button>
+	<button type="button" class="lty-playbtn" title="Keynote (Google I/O '18)"></button>
 </lite-youtube>
 
 <script>

--- a/variants/pe.html
+++ b/variants/pe.html
@@ -12,7 +12,7 @@
 <p id="done">...</p>
 
 <lite-youtube videoid="ogfYd705cRs" style="background-image: url('https://i.ytimg.com/vi/ogfYd705cRs/hqdefault.jpg');">
-	<div class="lty-playbtn"></div>
+	<button class="lty-playbtn" title="Keynote (Google I/O '18)"></button>
 </lite-youtube>
 
 <script>

--- a/variants/pe.html
+++ b/variants/pe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>lite-youtube-embed - progressively enhanced</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../src/lite-yt-embed.css" />
+</head>
+<body>
+<h1>progressively enhanced</h1>
+<p>After 2 seconds, the JS is executed and custom element defined.</p>
+<p id="done">...</p>
+
+<lite-youtube videoid="ogfYd705cRs" style="background-image: url('https://i.ytimg.com/vi/ogfYd705cRs/hqdefault.jpg');">
+	<div class="lty-playbtn"></div>
+</lite-youtube>
+
+<script>
+// artificial delay somewhat simulates a script[defer]
+setTimeout(_ => {
+  const elem = document.createElement('script');
+  elem.src = '../src/lite-yt-embed.js';
+  document.head.append(elem);
+
+  elem.onload = _ => {
+    customElements.define('lite-youtube', LiteYTEmbed);
+    document.querySelector('#done').textContent = 'Script complete.'
+  };
+}, 2000);
+</script>
+
+</body>
+</html>

--- a/variants/solo.html
+++ b/variants/solo.html
@@ -9,7 +9,7 @@
 <body>
 <h1><code>lite-youtube</code> custom element</h1>
 
-<lite-youtube videoid="ogfYd705cRs"></lite-youtube>
+<lite-youtube videoid="ogfYd705cRs" playlabel="Play Video: Keynote (Google I/O '18)"></lite-youtube>
 
 <script src="../src/lite-yt-embed.js"></script>
 

--- a/variants/solo.html
+++ b/variants/solo.html
@@ -12,10 +12,6 @@
 <lite-youtube videoid="ogfYd705cRs"></lite-youtube>
 
 <script src="../src/lite-yt-embed.js"></script>
-<script>
-  // Register custom element
-  customElements.define('lite-youtube', LiteYTEmbed);
-</script>
 
 </body>
 </html>


### PR DESCRIPTION
Pull request makes the play `<button>` a button with a title attribute

Title attribute defaults to `Play video: {ID}`, But can be overwritten with a data attr `data-playlabel` to allow custom/localised descriptive text.