### PR TITLE
Set margin on lite-youtube

### DIFF
--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -6,6 +6,7 @@ lite-youtube {
     background-position: center center;
     background-size: cover;
     cursor: pointer;
+    margin: 0 auto;
 }
 
 /* gradient */


### PR DESCRIPTION
I was trying this out and found margin is missing. The standard YouTube embed has margin set on the embedded iframe:

<img width="1396" alt="スクリーンショット 2019-11-24 00 33 01" src="https://user-images.githubusercontent.com/1000669/69481159-0ad41600-0e52-11ea-9111-c3b60f97bc22.png">

This PR matches this previous behavior, so trying out `lite-youtube` would not require adding extra CSS.