### PR TITLE
feat: attribute observation and property changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <li><a href="./variants/solo.html">lite-youtube-embed</a>
       <li><a href="./variants/pe.html">lite-youtube-embed - progressively enhanced</a>
       <li><a href="./variants/yt.html">normal youtube embed</a>
+      <li><a href="./variants/params.html">Lite embed with custom params</a></li>
     </ul>
   </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,32 @@ To use the custom embed you will need to:
 <lite-youtube videoid="ogfYd705cRs"></lite-youtube>
 ```
 
+### Additional Parameters
+
+YouTube supports a variety of different [player parameters](https://developers.google.com/youtube/player_parameters).
+These may be applied by using the `params` property and attribute.
+The `autoplay` attribute defaults to `1` for the lite embed element.
+
+```html
+<!-- Example to show a video player without controls -->
+<lite-youtube videoid="ogfYd705cRs" params="&controls=0"></lite-youtube>
+```
+
+```javascript
+// Create your element or get it via a DOM reference
+const embeddedPlayer = new LiteYTEmbed();
+embeddedPlayer.videoId = 'ogfYd705cRs';
+
+// Set the params using the property on the element
+embeddedPlayer.params = '&controls=0';
+
+// Add to the main DOM if not already present
+document.body.appendChild(embeddedPlayer);
+```
+
+You are free to use JavaScript to dynamically update the parameters after the element is in the DOM.
+The URL of the iframe will update immediately.
+
 ## Notes
 
 Note that the embed will be using youtube-nocookie.com instead of youtube.com in order

--- a/variants/duo.html
+++ b/variants/duo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>lite-youtube-embed</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="../src/lite-yt-embed.css" />
+</head>
+<body>
+<h1><code>lite-youtube</code> custom element</h1>
+
+<lite-youtube videoid="ogfYd705cRs"></lite-youtube>
+
+<lite-youtube videoid="kobvF5cs6xY"></lite-youtube>
+
+<script src="../src/lite-yt-embed.js"></script>
+
+</body>
+</html>

--- a/variants/params.html
+++ b/variants/params.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>lite-youtube-embed</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="../src/lite-yt-embed.css" />
+</head>
+<body>
+<h1><code>lite-youtube</code> custom element</h1>
+
+<p>
+    This is embedded with custom parameters to make the playback controls not display on the video.
+    You may use any parameters <a href="https://developers.google.com/youtube/player_parameters">supported by YouTube</a> that are applicable to a video embed.
+    Autoplay is always defaulted to `1` with this custom element.
+</p>
+
+<p>
+    The following embed has the params <pre>&amp;controls=0</pre> which turns off the controls in the video player.
+</p>
+
+<lite-youtube videoid="ogfYd705cRs" params="&controls=0"></lite-youtube>
+
+<script src="../src/lite-yt-embed.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Initial pass at adding attribute observers.
With this properties (where possible) were implemented with getters and setters.

A few other modifications were made to ease updating the iframe by creating and caching it in the constructor but not injecting it into the DOM to kick off any of the fetches for it (hopefully.)

Before merge:

* [x] Fix height/width _Turns out it was no longer fixed size already due to some aspect ratio changes. Simply removed the properties on the iframe to match the intent._
* [x] Update docs
* [x] Verify performance with creating iframe node but not injecting matches with creation just in time.
* [x] Verify I'm not insane when I'm not so tired doing this work.