### PR TITLE
Replace faux css play button with actual YT svg

### DIFF
--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -41,32 +41,14 @@ lite-youtube > iframe {
 
 /* play button */
 lite-youtube > .lty-playbtn {
-    width: 70px;
-    height: 46px;
-    background-color: #212121;
-    z-index: 1;
-    opacity: 0.8;
-    border-radius: 14%; /* TODO: Consider replacing this with YT's actual svg. Eh. */
-    transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
-}
-lite-youtube:hover > .lty-playbtn {
-    background-color: #f00;
-    opacity: 1;
-}
-/* play button triangle */
-lite-youtube > .lty-playbtn::before {
-    content: '';
-    border-style: solid;
-    border-width: 11px 0 11px 19px;
-    border-color: transparent transparent transparent #fff;
-}
-
-lite-youtube > .lty-playbtn,
-lite-youtube > .lty-playbtn::before {
+    width: 68px;
+    height: 48px;
     position: absolute;
+    transform: translate3d(-50%, -50%, 0);
     top: 50%;
     left: 50%;
-    transform: translate3d(-50%, -50%, 0);
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 68 48"><path fill="%23f00" fill-opacity="0.8" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z"></path><path d="M 45,24 27,14 27,34" fill="%23fff"></path></svg>');
+    z-index: 1;
 }
 
 /* Post-click styles */

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -47,8 +47,15 @@ lite-youtube > .lty-playbtn {
     transform: translate3d(-50%, -50%, 0);
     top: 50%;
     left: 50%;
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 68 48"><path fill="%23f00" fill-opacity="0.8" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z"></path><path d="M 45,24 27,14 27,34" fill="%23fff"></path></svg>');
     z-index: 1;
+    /* YT's actual play button svg */
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 68 48"><path fill="%23f00" fill-opacity="0.8" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z"></path><path d="M 45,24 27,14 27,34" fill="%23fff"></path></svg>');
+    filter: grayscale(100%);
+    transition: filter .1s cubic-bezier(0, 0, 0.2, 1);
+}
+
+lite-youtube:hover > .lty-playbtn {
+    filter: none;
 }
 
 /* Post-click styles */


### PR DESCRIPTION
I found todo in the code: `Consider replacing this with YT's actual svg.`.

This PR attempts to replace css rounding tricks for svg taken from YT.com.

I didnt manage to recreate hover state.

SVG in bg cannot be manipulated from hover state (I assume), so i made it always red.

Before:
<img width="155" alt="image" src="https://user-images.githubusercontent.com/546845/71114010-24594b00-21cf-11ea-9a37-fd1c7430bf25.png">

After:
<img width="218" alt="image" src="https://user-images.githubusercontent.com/546845/71113980-10ade480-21cf-11ea-9e31-5f4bada0fd47.png">
