### PR TITLE
feat: support params

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <ul>
       <li><a href="./variants/solo.html">lite-youtube-embed</a>
       <li><a href="./variants/pe.html">lite-youtube-embed - progressively enhanced</a>
+      <li><a href="./variants/params.html">lite-youtube-embed - with parameters</a></li>
       <li><a href="./variants/yt.html">normal youtube embed</a>
     </ul>
   </body>

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,16 @@ To use the custom embed you will need to:
 <lite-youtube videoid="ogfYd705cRs"></lite-youtube>
 ```
 
+### Additional Parameters
+
+YouTube supports a variety of different [player parameters](https://developers.google.com/youtube/player_parameters).
+These may be applied by using the `params` property and attribute.
+The `autoplay` attribute defaults to `1` for the lite embed element.
+
+```html
+<!-- Example to show a video player without controls -->
+<lite-youtube videoid="ogfYd705cRs" params="controls=0"></lite-youtube>
+
 ## Notes
 
 Note that the embed will be using youtube-nocookie.com instead of youtube.com in order

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -99,7 +99,7 @@ class LiteYTEmbed extends HTMLElement {
     }
 
     addIframe(){
-        const params = new URLSearchParams(this.getAttribute('params'));
+        const params = new URLSearchParams(this.getAttribute('params') || []);
         params.append('autoplay', '1');
         const iframeHTML = `
 <iframe width="560" height="315" frameborder="0"

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -99,10 +99,12 @@ class LiteYTEmbed extends HTMLElement {
     }
 
     addIframe(){
+        const params = new URLSearchParams(this.getAttribute('params'));
+        params.append('autoplay', '1');
         const iframeHTML = `
 <iframe width="560" height="315" frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen
-  src="https://www.youtube-nocookie.com/embed/${this.videoId}?autoplay=1"
+  src="https://www.youtube-nocookie.com/embed/${this.videoId}?${params.toString()}"
 ></iframe>`;
         this.insertAdjacentHTML('beforeend', iframeHTML);
         this.classList.add('lyt-activated');

--- a/variants/params.html
+++ b/variants/params.html
@@ -11,7 +11,7 @@
 
 <p>
     This is embedded with custom parameters to make the playback controls not display on the video.
-    You may use any parameters <a href="https://developers.google.com/youtube/player_parameters">supported by YouTube</a> that are applicable to a video embed.
+    You may use any <a href="https://developers.google.com/youtube/player_parameters#Parameters">parameters supported by the YouTube IFrame Player API</a>.
     Autoplay is always defaulted to `1` with this custom element.
 </p>
 

--- a/variants/params.html
+++ b/variants/params.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>lite-youtube-embed</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="../src/lite-yt-embed.css" />
+</head>
+<body>
+<h1><code>lite-youtube</code> custom element</h1>
+
+<p>
+    This is embedded with custom parameters to make the playback controls not display on the video.
+    You may use any parameters <a href="https://developers.google.com/youtube/player_parameters">supported by YouTube</a> that are applicable to a video embed.
+    Autoplay is always defaulted to `1` with this custom element.
+</p>
+
+<p>
+    The following embed has the params <pre>controls=0</pre> which turns off the controls in the video player.
+</p>
+
+<lite-youtube videoid="ogfYd705cRs" params="controls=0"></lite-youtube>
+
+<script src="../src/lite-yt-embed.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
The absolute most minimal thing we can do to support generic `params`. Nothing to do with updating should any attributes change.

Also takes advantage of `URLSearchParams` as discussed in #28. This makes the work we do far cleaner and less error prone. Really nice that the constructor takes a string to start the data off with.