### PR TITLE
Fix: invalid property name and value (crossOrigin)

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -70,7 +70,7 @@ class LiteYTEmbed extends HTMLElement {
         if (as) {
             linkElem.as = as;
         }
-        linkElem.crossorigin = true;
+        linkElem.crossOrigin = 'anonymous';
         document.head.append(linkElem);
     }
 


### PR DESCRIPTION
The attribute crossorigin use with camelcase notation (crossOrigin) as a DOM property.

Setting the attribute name to an empty value, like crossorigin or crossorigin="", is the same as "anonymous".