### PR TITLE
set max-width of 720px

### DIFF
--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -6,7 +6,7 @@ lite-youtube {
     background-position: center center;
     background-size: cover;
     cursor: pointer;
-    max-width: 640px;
+    max-width: 720px;
 }
 
 /* gradient */

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -6,6 +6,7 @@ lite-youtube {
     background-position: center center;
     background-size: cover;
     cursor: pointer;
+    max-width: 640px;
 }
 
 /* gradient */


### PR DESCRIPTION
I've always been bugged that the demo at https://paulirish.github.io/lite-youtube-embed/ was SUPERSIZED

Looking around.. there is no "standard" width for yt embedds. Currently youtube.com gives embed iframe code with `<iframe width="560"`. Then on https://developers.google.com/youtube/youtube_player_demo it has a 720px iframe. And [on this docs page](https://developers.google.com/youtube/iframe_api_reference) it instantiates one that's 640px

I had 600px in mind originally, but it does feel a tad small. The number itself shouldnt matter much because folks can override it easily in their own styles.  But..  we'll go with 720.