### PR TITLE
drop crossorigin=anonymous on preload/preconnect

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -66,7 +66,6 @@ class LiteYTEmbed extends HTMLElement {
         if (as) {
             linkElem.as = as;
         }
-        linkElem.crossOrigin = 'anonymous';
         document.head.append(linkElem);
     }
 


### PR DESCRIPTION
afaik i[ originally added ](https://github.com/paulirish/lite-youtube-embed/commit/88265d0a7571757062171fdd364b4ffdaf321d5c)the `crossorigin` bit out of suspicion. 

im not sure it was entirely neccessary.

And it seems this has changed more because we see the errors in https://github.com/paulirish/lite-youtube-embed/issues/59

![image](https://user-images.githubusercontent.com/39191/96817006-41ecd780-13d3-11eb-8c6a-40c811631a60.png)

----------

I have to admit I don't completely understand the role of credentials in this preload and how this ends up with CORS issues.. But..... I'm comfortable removing the crossorigin/credentials item from before. Seems like it's a win for perf and now plays well with improved privacy controls implemented by the browser.

fixes #59 