### PR TITLE
Pointer cursor on the play button as well

### DIFF
--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -46,6 +46,7 @@ lite-youtube > .lty-playbtn {
     width: 68px;
     height: 48px;
     position: absolute;
+    cursor: pointer;
     transform: translate3d(-50%, -50%, 0);
     top: 50%;
     left: 50%;


### PR DESCRIPTION
Small thing I've noticed is that `lite-youtube` has `cursor: pointer;` set, but the same is missing when hovering over the button.

This change just adds `cursor: pointer;` to the `lty-playbtn` as well.