### PR TITLE
Don't override existing background images set via CSS

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -27,11 +27,13 @@ class LiteYTEmbed extends HTMLElement {
          *       - When doing this, apply referrerpolicy (https://github.com/ampproject/amphtml/pull/3940)
          * TODO: Consider using webp if supported, falling back to jpg
          */
-        this.posterUrl = `https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg`;
-        // Warm the connection for the poster image
-        LiteYTEmbed.addPrefetch('preload', this.posterUrl, 'image');
+        if (!this.style.backgroundImage) {
+          this.posterUrl = `https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg`;
+          // Warm the connection for the poster image
+          LiteYTEmbed.addPrefetch('preload', this.posterUrl, 'image');
 
-        this.style.backgroundImage = `url("${this.posterUrl}")`;
+          this.style.backgroundImage = `url("${this.posterUrl}")`;
+        }
 
         // Set up play button, and its visually hidden label
         if (!playBtnEl) {
@@ -119,5 +121,5 @@ class LiteYTEmbed extends HTMLElement {
         this.querySelector('iframe').focus();
     }
 }
-// Register custome element
+// Register custom element
 customElements.define('lite-youtube', LiteYTEmbed);


### PR DESCRIPTION
This is @IORoot's idea from #64

This makes sure we don't override existing background images that may have been set by the progressive enhancement approach. This allows authors to override the YouTube thumbnail if they run into quality issues, or want to use a `webp` image, or need to use a different thumbnail, because the YouTube one is an awkward capture of a person speaking mid-word, and they can't get that person's approval to put such an awkward pose on the homepage of the website… You know the sort of things that crop up! :) 

I understand there are existing issues about this (#64, #70, #54). To me, this seems like a simple interim approach that allows people who want to override the image to do so, without affecting behaviour for users who are not already setting a background image.

In my work we allow CMS users to add custom cover images to videos (often higher quality ones or a better choice of image than provided by YouTube),  but our custom background image was being overridden when the component was initialised. 