### PR TITLE
feat: support webp format with jpg fallback

### DIFF
--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -22,6 +22,7 @@ lite-youtube::before {
     padding-bottom: 50px;
     width: 100%;
     transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+    z-index: 1;
 }
 
 /* responsive iframe with a 16:9 aspect ratio
@@ -39,6 +40,21 @@ lite-youtube > iframe {
     top: 0;
     left: 0;
     border: 0;
+}
+
+/* images */
+lite-youtube > picture {
+    position: absolute;
+    width: 100%;
+    top: 0;
+    bottom: 0;
+}
+
+lite-youtube > picture img {
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    width: 100%;
 }
 
 /* play button */

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -44,7 +44,7 @@ class LiteYTEmbed extends HTMLElement {
             // in case we want to add again preload after detecting 
             // const preload = LiteYTEmbed.checkWebPSupport() ? webp : jpg
             // LiteYTEmbed.addPrefetch('preload', preload, 'image');
-            LiteYTEmbed.addPrefetch('preload', img, 'image', 'image/webp')
+            LiteYTEmbed.addPrefetch('preload', webp, 'image', 'image/webp')
 
             picture.append(source)
             picture.append(img)

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -11,7 +11,7 @@
  *   https://github.com/vb/lazyframe
  */
 class LiteYTEmbed extends HTMLElement {
-    connectedCallback() {
+    async connectedCallback() {
         this.videoId = this.getAttribute('videoid');
 
         let playBtnEl = this.querySelector('.lty-playbtn');
@@ -25,9 +25,13 @@ class LiteYTEmbed extends HTMLElement {
          *
          * TODO: Do the sddefault->hqdefault fallback
          *       - When doing this, apply referrerpolicy (https://github.com/ampproject/amphtml/pull/3940)
-         * TODO: Consider using webp if supported, falling back to jpg
          */
-        this.posterUrl = `https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg`;
+        const isWebpSupported = await LiteYTEmbed.checkWebPSupport()
+  
+        this.posterUrl = isWebpSupported
+          ? `https://i.ytimg.com/vi_webp/${this.videoId}/hqdefault.webp`
+          : `https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg`;
+    
         // Warm the connection for the poster image
         LiteYTEmbed.addPrefetch('preload', this.posterUrl, 'image');
 
@@ -71,6 +75,26 @@ class LiteYTEmbed extends HTMLElement {
             linkEl.as = as;
         }
         document.head.append(linkEl);
+    }
+
+    /**
+     * Check WebP support for the user
+     */
+    static checkWebPSupport() {
+      if (typeof LiteYTEmbed.hasWebPSupport !== 'undefined')
+        return Promise.resolve(LiteYTEmbed.hasWebPSupport);
+  
+      return new Promise(resolve => {
+        const resolveAndSaveValue = value => {
+          LiteYTEmbed.hasWebPSupport = value;
+          resolve(value);
+        }
+  
+        const img = new Image();
+        img.onload = () => resolveAndSaveValue(true);
+        img.onerror = () => resolveAndSaveValue(false);
+        img.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=';
+      })
     }
 
     /**


### PR DESCRIPTION
In order to improve web performance we're using webp when available.

- [x] Added support to webp
- [x] Keep `jpg` fallback.

https://user-images.githubusercontent.com/1561955/109354468-2791a180-787e-11eb-8fd0-a4f2bb87689c.mp4

This is addressing some issues from: https://github.com/paulirish/lite-youtube-embed/issues/70