### PR TITLE
Added a title attribute to render title prior to load

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,13 @@ If you want to provide a custom poster image, just set it as the background-imag
 
 Demo: https://paulirish.github.io/lite-youtube-embed/variants/custom-poster-image.html
 
+## Add a video title
+
+If you want to display a title prior to loading the full embed, set the `title` attribute:
+```html
+<lite-youtube videoid="ogfYd705cRs" title="Keynote (Google I/O '18)"></lite-youtube>
+```
+
 ## Other lite embeds
 
 - Youtube: [`justinribeiro/lite-youtube`](https://github.com/justinribeiro/lite-youtube) - Shadow-DOM-using port of paulirish/lite-youtube-embed

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -83,3 +83,36 @@ lite-youtube.lyt-activated > .lty-playbtn {
     white-space: nowrap;
     width: 1px;
   }
+
+lite-youtube h1.lyt-title-text {
+    font-family: "YouTube Noto",Roboto,Arial,Helvetica,sans-serif;
+    color: hsla(0,0%,100%,.9);
+    text-align: left;
+    direction: ltr;
+    line-height: 1.3;
+    text-shadow: 0 0 2px rgba(0,0,0,.5);
+    vertical-align: top;
+    font-size: 18px;
+    font-weight: 400;
+    flex: 1;
+    padding-top:  21px;
+    padding-left:  20px;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    word-wrap: normal;
+    text-overflow: ellipsis;
+    position:  relative;
+}
+@media(min-width: 800px){
+    lite-youtube h1.lyt-title-text {
+        font-size: 20px;
+    }
+}
+lite-youtube:hover h1.lyt-title-text {
+    color: white;
+}
+lite-youtube.lyt-activated > .lyt-title-text {
+    opacity: 0;
+    pointer-events: none;
+}

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -18,6 +18,8 @@ class LiteYTEmbed extends HTMLElement {
         // A label for the button takes priority over a [playlabel] attribute on the custom-element
         this.playLabel = (playBtnEl && playBtnEl.textContent.trim()) || this.getAttribute('playlabel') || 'Play';
 
+        this.title = this.getAttribute('title') || false;
+
         /**
          * Lo, the youtube placeholder image!  (aka the thumbnail, poster image, etc)
          *
@@ -33,6 +35,13 @@ class LiteYTEmbed extends HTMLElement {
           LiteYTEmbed.addPrefetch('preload', this.posterUrl, 'image');
 
           this.style.backgroundImage = `url("${this.posterUrl}")`;
+        }
+
+        if( this.title ) {
+            const titleEl = document.createElement('h1');
+            titleEl.classList.add('lyt-title-text');
+            titleEl.textContent = this.title;
+            this.append( titleEl );
         }
 
         // Set up play button, and its visually hidden label

--- a/variants/title.html
+++ b/variants/title.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>lite-youtube-embed - with title</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../src/lite-yt-embed.css" />
+</head>
+<body>
+<h1><code>lite-youtube</code> custom element</h1>
+
+<p>Add the title attribute to display a title prior to clicking the lite element.</p>
+
+<lite-youtube videoid="ogfYd705cRs" title="Play: Keynote (Google I/O '18)"></lite-youtube>
+
+<script src="../src/lite-yt-embed.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds a title attribute so the pre-clicked element displays a title. The title's style is basically the same as YouTube's.