### PR TITLE
Added lazy parameter and test cases for preload

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -13,6 +13,7 @@
 class LiteYTEmbed extends HTMLElement {
     connectedCallback() {
         this.videoId = this.getAttribute('videoid');
+        this.lazy = this.getAttribute('lazy');
 
         let playBtnEl = this.querySelector('.lty-playbtn');
         // A label for the button takes priority over a [playlabel] attribute on the custom-element
@@ -29,8 +30,11 @@ class LiteYTEmbed extends HTMLElement {
          */
         if (!this.style.backgroundImage) {
           this.posterUrl = `https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg`;
-          // Warm the connection for the poster image
-          LiteYTEmbed.addPrefetch('preload', this.posterUrl, 'image');
+          
+          if (this.lazy === null) {
+              // Warm the connection for the poster image
+              LiteYTEmbed.addPrefetch('preload', this.posterUrl, 'image');
+          }
 
           this.style.backgroundImage = `url("${this.posterUrl}")`;
         }

--- a/variants/lazy.html
+++ b/variants/lazy.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>lite-youtube-embed</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="../src/lite-yt-embed.css" />
+  </head>
+  <body>
+    <h1><code>lite-youtube</code> custom element without preload</h1>
+
+    <div style="height: 100vh">
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo tenetur
+        commodi, fugit iste repudiandae amet vel mollitia excepturi. Velit
+        expedita illum magnam quod quam at sequi repudiandae ad qui ab
+        perspiciatis minima possimus officia voluptates hic accusamus
+        consequatur, quo corporis sit rem placeat nihil, optio, ut repellat!
+        Quis perferendis facilis odio aut excepturi ratione, ex quo ipsam earum
+        adipisci dolores nulla optio, exercitationem nisi, eveniet laboriosam
+        debitis nesciunt? Quam fugit eveniet dignissimos dolore, suscipit ipsam
+        velit ducimus doloremque, blanditiis, aperiam dolorum perferendis. Ut ea
+        similique enim excepturi necessitatibus temporibus repellat unde ipsum
+        veniam esse ducimus nesciunt voluptate sapiente, repudiandae error
+        laudantium facere molestias aliquid consectetur! Magni, itaque aliquam
+        ex porro quibusdam error omnis eveniet dignissimos corrupti mollitia.
+        Accusantium animi odio ab tempore amet minus error praesentium cum
+        tempora optio veniam quae, repellendus dolores sint eius laboriosam
+        saepe quasi excepturi alias. Ipsa libero nesciunt fuga odit excepturi
+        suscipit dicta, accusamus delectus dolores autem magni repellendus
+        deleniti, nihil corrupti! Inventore accusamus quaerat ducimus,
+        cupiditate obcaecati natus nihil minima, amet quae alias unde sint in
+        deleniti nemo molestias magnam. Nobis consequatur enim ut eius adipisci,
+        tempore eaque fuga quis dolore natus quod atque. Dolorum delectus, earum
+        debitis vitae aliquam magnam! Nihil, ad impedit.
+      </p>
+      <p>Scroll down!</p>
+    </div>
+
+    <lite-youtube
+      videoid="ogfYd705cRs"
+      playlabel="Play: Keynote (Google I/O '18)"
+      lazy
+    ></lite-youtube>
+
+    <script src="../src/lite-yt-embed.js"></script>
+  </body>
+</html>

--- a/variants/preload.html
+++ b/variants/preload.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>lite-youtube-embed</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="../src/lite-yt-embed.css" />
+    <link rel="preload" href="https://i.ytimg.com/vi/ogfYd705cRs/hqdefault.jpg" as="image">
+  </head>
+  <body>
+    <h1><code>lite-youtube</code> custom element with preload in document</h1>
+
+    <div style="height: 100vh">
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo tenetur
+        commodi, fugit iste repudiandae amet vel mollitia excepturi. Velit
+        expedita illum magnam quod quam at sequi repudiandae ad qui ab
+        perspiciatis minima possimus officia voluptates hic accusamus
+        consequatur, quo corporis sit rem placeat nihil, optio, ut repellat!
+        Quis perferendis facilis odio aut excepturi ratione, ex quo ipsam earum
+        adipisci dolores nulla optio, exercitationem nisi, eveniet laboriosam
+        debitis nesciunt? Quam fugit eveniet dignissimos dolore, suscipit ipsam
+        velit ducimus doloremque, blanditiis, aperiam dolorum perferendis. Ut ea
+        similique enim excepturi necessitatibus temporibus repellat unde ipsum
+        veniam esse ducimus nesciunt voluptate sapiente, repudiandae error
+        laudantium facere molestias aliquid consectetur! Magni, itaque aliquam
+        ex porro quibusdam error omnis eveniet dignissimos corrupti mollitia.
+        Accusantium animi odio ab tempore amet minus error praesentium cum
+        tempora optio veniam quae, repellendus dolores sint eius laboriosam
+        saepe quasi excepturi alias. Ipsa libero nesciunt fuga odit excepturi
+        suscipit dicta, accusamus delectus dolores autem magni repellendus
+        deleniti, nihil corrupti! Inventore accusamus quaerat ducimus,
+        cupiditate obcaecati natus nihil minima, amet quae alias unde sint in
+        deleniti nemo molestias magnam. Nobis consequatur enim ut eius adipisci,
+        tempore eaque fuga quis dolore natus quod atque. Dolorum delectus, earum
+        debitis vitae aliquam magnam! Nihil, ad impedit.
+      </p>
+      <p>Scroll down!</p>
+    </div>
+
+    <lite-youtube
+      videoid="ogfYd705cRs"
+      playlabel="Play: Keynote (Google I/O '18)"
+    ></lite-youtube>
+
+    <script src="../src/lite-yt-embed.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Tackles #102.

I have added the optional `lazy` attribute to not change existent behaviour and created two new test cases:
- /variants/lazy.html - uses the new `lazy` param and pushes the image outside of the viewport to lower the priority of the request
- /variants/preload.html - uses a normal `<link rel="preload">`

_Note: Possibly `lazy` is a misleading name as the image is not really lazy loaded, just not preloaded._