### PR TITLE
remove poster image preload

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -28,11 +28,7 @@ class LiteYTEmbed extends HTMLElement {
          * TODO: Consider using webp if supported, falling back to jpg
          */
         if (!this.style.backgroundImage) {
-          this.posterUrl = `https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg`;
-          // Warm the connection for the poster image
-          LiteYTEmbed.addPrefetch('preload', this.posterUrl, 'image');
-
-          this.style.backgroundImage = `url("${this.posterUrl}")`;
+          this.style.backgroundImage = `url("https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg")`;
         }
 
         // Set up play button, and its visually hidden label


### PR DESCRIPTION
@kevinfarrugia brought this up in #102 and #103 ...

I found that historically the preload was separated from the backgroundImage setting: https://github.com/paulirish/lite-youtube-embed/commit/0478f28838d33be4239b4573e221771f86609280

but then they merged together  for good reason: https://github.com/paulirish/lite-youtube-embed/commit/0221be1727c6c338d8ae2e4cac5c8aa106ed5794

so now theres really no reason to not let the css background image kick off its own network request.