### PR TITLE
Remove `href` from button to prevent possible navigation

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -44,6 +44,7 @@ class LiteYTEmbed extends HTMLElement {
             playBtnLabelEl.textContent = this.playLabel;
             playBtnEl.append(playBtnLabelEl);
         }
+        playBtnEl.removeAttribute('href');
 
         // On hover (or tap), warm up the TCP connections we're (likely) about to use.
         this.addEventListener('pointerover', LiteYTEmbed.warmConnections, {once: true});


### PR DESCRIPTION
Closes #123

Better support for the progressive enhancement approach of making the play button a link before the custom element loads. Currently with that approach, clicking the play button will navigate to YouTube even after the custom element has loaded. This PR removes the link’s `href` in the `connectedCallback` to stop that from happening.