### PR TITLE
Make the entire element clickable

### DIFF
--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -44,14 +44,14 @@ lite-youtube > iframe {
 /* play button */
 lite-youtube > .lty-playbtn {
     display: block;
-    width: 68px;
-    height: 48px;
+    width: 100%;
+    height: 100%;
     position: absolute;
     cursor: pointer;
-    transform: translate3d(-50%, -50%, 0);
-    top: 50%;
-    left: 50%;
     z-index: 1;
+    background-size: 68px 48px;
+    background-repeat: no-repeat;
+    background-position: center;
     background-color: transparent;
     /* YT's actual play button svg */
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -44,14 +44,16 @@ lite-youtube > iframe {
 /* play button */
 lite-youtube > .lty-playbtn {
     display: block;
+    /* Make the button element cover the whole area for a large hover/click target… */
     width: 100%;
     height: 100%;
-    position: absolute;
-    cursor: pointer;
-    z-index: 1;
+    /* …but visually it's still the same size */
     background-size: 68px 48px;
     background-repeat: no-repeat;
     background-position: center;
+    position: absolute;
+    cursor: pointer;
+    z-index: 1;
     background-color: transparent;
     /* YT's actual play button svg */
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -48,15 +48,12 @@ lite-youtube > .lty-playbtn {
     width: 100%;
     height: 100%;
     /* …but visually it's still the same size */
-    background-size: 68px 48px;
-    background-repeat: no-repeat;
-    background-position: center;
+    background: no-repeat center/68px 48px;
+    /* YT's actual play button svg */
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
     position: absolute;
     cursor: pointer;
     z-index: 1;
-    background-color: transparent;
-    /* YT's actual play button svg */
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
     filter: grayscale(100%);
     transition: filter .1s cubic-bezier(0, 0, 0.2, 1);
     border: none;


### PR DESCRIPTION
When using the [progressively enhanced recipe](https://github.com/paulirish/lite-youtube-embed#pro-usage-load-w-js-deferred-aka-progressive-enhancement), this PR makes the fallback thumbnail fully clickable. Previously, the click-able area for the link off to YouTube was the tiny red YouTube play button in the middle. Now, you can click anywhere on the thumbnail.

(JavaScript disabled or before the JS kicks in)

Before | After (can click anywhere on the thumbnail)
--- | ---
![](https://github.com/paulirish/lite-youtube-embed/assets/558581/3c58a05c-9115-4a40-b363-f83dd50e4b66) | ![](https://github.com/paulirish/lite-youtube-embed/assets/558581/27d8fc45-e936-4a9c-9a80-facbc042483e)

