### PR TITLE
Mute videos on iOS devices when tapped

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -137,30 +137,30 @@ class LiteYTEmbed extends HTMLElement {
     async addIframe(){
         if (this.classList.contains('lyt-activated')) return;
         this.classList.add('lyt-activated');
-
+    
         const params = new URLSearchParams(this.getAttribute('params') || []);
         params.append('autoplay', '1');
         params.append('playsinline', '1');
-
+    
+        if (/iPad|iPhone|iPod/.test(navigator.platform)) {
+            params.append('mute', '1'); // Mute only if on iPad or iPhone
+        }
+    
         if (this.needsYTApiForAutoplay) {
             return this.addYTPlayerIframe(params);
         }
-
+    
         const iframeEl = document.createElement('iframe');
         iframeEl.width = 560;
         iframeEl.height = 315;
-        // No encoding necessary as [title] is safe. https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#:~:text=Safe%20HTML%20Attributes%20include
         iframeEl.title = this.playLabel;
         iframeEl.allow = 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture';
         iframeEl.allowFullscreen = true;
-        // AFAIK, the encoding here isn't necessary for XSS, but we'll do it only because this is a URL
-        // https://stackoverflow.com/q/64959723/89484
         iframeEl.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(this.videoId)}?${params.toString()}`;
         this.append(iframeEl);
-
-        // Set focus for a11y
+    
         iframeEl.focus();
-    }
+    }    
 }
 // Register custom element
 customElements.define('lite-youtube', LiteYTEmbed);


### PR DESCRIPTION
The change introduces a condition to mute videos when they are played on an iPad or iPhone. Specifically, it adds the parameter `'mute', '1'` to the video URL if the platform is identified as iPad or iPhone. This is achieved using the test `/iPad|iPhone|iPod/.test(navigator.platform)`. The purpose is to mute videos automatically on these devices upon tapping based on the findings I mentioned here:

https://github.com/paulirish/lite-youtube-embed/commit/9dfd33a975b97410769981579aa7301118c1cac9#commitcomment-130244618