### PR TITLE
Add a `js-api` attribute to opt-in to the YouTube Iframe Player API

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
       <li><a href="./variants/custom-poster-image.html">lite-youtube-embed - custom poster image</a>
       <li><a href="./variants/params.html">lite-youtube-embed - with parameters</a></li>
       <li><a href="./variants/multiple-embeds.html">lite-youtube-embed - multiple embeds on same page</a>
+      <li><a href="./variants/js-api.html">lite-youtube-embed - with access to iframe JavaScript API</a>
       <li><a href="./variants/yt.html">normal youtube embed</a>
     </ul>
   </body>

--- a/variants/js-api.html
+++ b/variants/js-api.html
@@ -15,6 +15,7 @@
 async function seekTo(id, seconds) {
 	let video = document.querySelector(`lite-youtube[videoid='${id}']`);
 	let player = await video.getPlayer();
+	// https://developers.google.com/youtube/iframe_api_reference#seekTo
 	player?.seekTo(seconds, true);
 }
 </script>

--- a/variants/js-api.html
+++ b/variants/js-api.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>lite-youtube-embed</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../src/lite-yt-embed.css" />
+</head>
+<body>
+<h1><code>lite-youtube</code> with JavaScript API</h1>
+
+<lite-youtube videoid="ogfYd705cRs" js-api playlabel="Play: Keynote (Google I/O '18)"></lite-youtube>
+
+<script>
+async function seekTo(id, seconds) {
+	let video = document.querySelector(`lite-youtube[videoid='${id}']`);
+	let player = await video.getPlayer();
+	player?.seekTo(seconds, true);
+}
+</script>
+
+<button type="button" onclick="seekTo('ogfYd705cRs', 5)">Skip to 00:05</button>
+<button type="button" onclick="seekTo('ogfYd705cRs', 10)">Skip to 00:10</button>
+<button type="button" onclick="seekTo('ogfYd705cRs', 60)">Skip to 01:00</button>
+
+<script src="../src/lite-yt-embed.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Allows using the `getPlayer` asynchronous method to access the `player` instance to control the video.

https://developers.google.com/youtube/iframe_api_reference#seekTo

Added an additional test/demo that shows usage examples.

Inspired by work on this stream: https://www.youtube.com/watch?v=MrVMewBq0jE