### PR TITLE
Replace top gradient PNG with `linear-gradient`

### DIFF
--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -15,7 +15,7 @@ lite-youtube::before {
     display: block;
     position: absolute;
     top: 0;
-    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.67) 0%, rgba(0, 0, 0, 0.54) 14%, rgba(0, 0, 0, 0.15) 54%, rgba(0, 0, 0, 0.05) 72%, rgba(0, 0, 0, 0) 94%);
+    background-image: linear-gradient(180deg, rgb(0 0 0 / 67%) 0%, rgb(0 0 0 / 54%) 14%, rgb(0 0 0 / 15%) 54%, rgb(0 0 0 / 5%) 72%, rgb(0 0 0 / 0%) 94%);
     background-position: top;
     background-repeat: repeat-x;
     height: 99px;

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -15,11 +15,10 @@ lite-youtube::before {
     display: block;
     position: absolute;
     top: 0;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAADGCAYAAAAT+OqFAAAAdklEQVQoz42QQQ7AIAgEF/T/D+kbq/RWAlnQyyazA4aoAB4FsBSA/bFjuF1EOL7VbrIrBuusmrt4ZZORfb6ehbWdnRHEIiITaEUKa5EJqUakRSaEYBJSCY2dEstQY7AuxahwXFrvZmWl2rh4JZ07z9dLtesfNj5q0FU3A5ObbwAAAABJRU5ErkJggg==);
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.67) 0%, rgba(0, 0, 0, 0.54) 14%, rgba(0, 0, 0, 0.15) 54%, rgba(0, 0, 0, 0.05) 72%, rgba(0, 0, 0, 0) 94%);
     background-position: top;
     background-repeat: repeat-x;
-    height: 60px;
-    padding-bottom: 50px;
+    height: 99px;
     width: 100%;
     transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
 }

--- a/src/lite-yt-embed.css
+++ b/src/lite-yt-embed.css
@@ -15,12 +15,10 @@ lite-youtube::before {
     display: block;
     position: absolute;
     top: 0;
+    /* Pixel-perfect port of YT's gradient PNG, using https://github.com/bluesmoon/pngtocss plus optimizations */
     background-image: linear-gradient(180deg, rgb(0 0 0 / 67%) 0%, rgb(0 0 0 / 54%) 14%, rgb(0 0 0 / 15%) 54%, rgb(0 0 0 / 5%) 72%, rgb(0 0 0 / 0%) 94%);
-    background-position: top;
-    background-repeat: repeat-x;
     height: 99px;
     width: 100%;
-    transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
 }
 
 /* responsive iframe with a 16:9 aspect ratio


### PR DESCRIPTION
First.. big thanks to  #132 and #88 (@xplosionmind  and @jakeparis) who both did similar work.  But I've been a super stickler for accuracy and wanted a pixel perfect match to the YT gradient.

Turns out 13 years ago Nicole Sullivan inspired some folks to make exactly the tool that we needed: https://www.stubbornella.org/2011/04/25/css-3-gradients/

I used https://github.com/bluesmoon/pngtocss/ to get the exact gradient definition. (Perfect alpha values are typically the part that's hard to get by hand).   

YT's png file is 198px but is displayed within a div thats 98px tall. So then we just needed to take half of the values, double the color stop positions.. and then code-golf the bytes down.

Overall it's a 161 byte savings. But more importantly one less network request (yes data-uri's still invoke a whole bunch of network request stuff in the browser).

