### PR TITLE
Fix accessibility of progressive enhancement pattern

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -32,10 +32,17 @@ class LiteYTEmbed extends HTMLElement {
 
         // Set up play button, and its visually hidden label
         if (!playBtnEl) {
-            playBtnEl = document.createElement('button');
-            playBtnEl.type = 'button';
-            playBtnEl.classList.add('lty-playbtn');
+            playBtnEl = this.createPlayBtn();
             this.append(playBtnEl);
+        }
+        // If the play button is a link, convert it to a button so it is interactive but doesn’t trigger a navigation.
+        if (playBtnEl.tagName === 'A') {
+            const isFocused = playBtnEl === document.activeElement;
+            const btnEl = this.createPlayBtn();
+            playBtnEl.replaceWith(btnEl);
+            // Preserve focus state if link is replaced with button.
+            if (isFocused) btnEl.focus();
+            playBtnEl = btnEl;
         }
         if (!playBtnEl.textContent) {
             const playBtnLabelEl = document.createElement('span');
@@ -45,8 +52,6 @@ class LiteYTEmbed extends HTMLElement {
         }
 
         this.addNoscriptIframe();
-
-        playBtnEl.removeAttribute('href');
 
         // On hover (or tap), warm up the TCP connections we're (likely) about to use.
         this.addEventListener('pointerover', LiteYTEmbed.warmConnections, {once: true});
@@ -191,6 +196,13 @@ class LiteYTEmbed extends HTMLElement {
         // https://stackoverflow.com/q/64959723/89484
         iframeEl.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(this.videoId)}?${this.getParams().toString()}`;
         return iframeEl;
+    }
+
+    createPlayBtn(){
+        const btnEl = document.createElement('button');
+        btnEl.type = 'button';
+        btnEl.classList.add('lty-playbtn');
+        return btnEl;
     }
 
     /**


### PR DESCRIPTION
In #124 I naïvely “fixed” the issue of the play button being a link when following the [progressive enhancement pattern](https://github.com/paulirish/lite-youtube-embed?tab=readme-ov-file#pro-usage-load-w-js-deferred-aka-progressive-enhancement) by removing the `href` attribute.

However, this introduced an accessibility issue: `<a>` without an `href` attribute is considered non-interactive, and therefore can’t be tabbed to by keyboard users, preventing them from playing the video.

This PR seeks to fix this more correctly by replacing an `<a>` element entirely with a `<button>` when the custom element loads. This preserves interactive semantics.

To test I loaded the progressive enhancement example. Before this change, the play button is not focusable with the keyboard. After this change, the play button can be focused as expected.