### PR TITLE
Accessibility Improvements for PE Pattern

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -52,8 +52,8 @@ class LiteYTEmbed extends HTMLElement {
             playBtnEl.setAttribute('tabindex', '0');
             playBtnEl.setAttribute('role', 'button');
             // fake button needs keyboard help
-            playBtnEl.addEventListener('keypress', e => {
-                if( e.which === 13 || e.which === 32 ){
+            playBtnEl.addEventListener('keydown', e => {
+                if( e.key === 'Enter' || e.key === ' ' ){
                     e.preventDefault();
                     this.activate();
                 }

--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -46,10 +46,23 @@ class LiteYTEmbed extends HTMLElement {
 
         this.addNoscriptIframe();
 
-        playBtnEl.removeAttribute('href');
+        // for the PE pattern, change anchor's semantics to button
+        if(playBtnEl.nodeName === 'A'){
+            playBtnEl.removeAttribute('href');
+            playBtnEl.setAttribute('tabindex', '0');
+            playBtnEl.setAttribute('role', 'button');
+            // fake button needs keyboard help
+            playBtnEl.addEventListener('keypress', e => {
+                if( e.which === 13 || e.which === 32 ){
+                    e.preventDefault();
+                    this.activate();
+                }
+            });
+        }
 
         // On hover (or tap), warm up the TCP connections we're (likely) about to use.
         this.addEventListener('pointerover', LiteYTEmbed.warmConnections, {once: true});
+        this.addEventListener('focusin', LiteYTEmbed.warmConnections, {once: true});
 
         // Once the user clicks, add the real iframe and drop our play button
         // TODO: In the future we could be like amp-youtube and silently swap in the iframe during idle time


### PR DESCRIPTION
Hey! A couple of things that seemed they may help.

In the progressive enhancement pattern, the anchor's href is removed and it is meant to play the role of a play button from there. Without its href though, it lost its ability to gain keyboard focus or receive keyboard interaction (return or space), and it no longer conveyed any element meaning beyond a generic element. 

Adding a role of button and tabindex gives it some buttony semantics and focusability. The event handlers give it buttony keyboard handling for space and enter. 

And then the focusin addition is just to warm connections for keyboard users too.