### PR TITLE
Workaround for Error 153

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -201,6 +201,8 @@ class LiteYTEmbed extends HTMLElement {
         iframeEl.title = this.playLabel;
         iframeEl.allow = 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture';
         iframeEl.allowFullscreen = true;
+        // Required by Youtube to fix Error 153
+        iframeEl.referrerPolicy = 'strict-origin-when-cross-origin';
         // AFAIK, the encoding here isn't necessary for XSS, but we'll do it only because this is a URL
         // https://stackoverflow.com/q/64959723/89484
         iframeEl.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(this.videoId)}?${this.getParams().toString()}`;


### PR DESCRIPTION
Due to recent [changes](https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity) in the Youtube terms of conditions, the embed may fail (e.g. if you have a strict referrer origin in the parent page).

(I'm aware that this may break the privacy of the user, there isn't a reliable solution for now unless Youtube backtracks the decision)