### PR TITLE
prevent double registration of customElements

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -238,4 +238,6 @@ class LiteYTEmbed extends HTMLElement {
     }
 }
 // Register custom element
-customElements.define('lite-youtube', LiteYTEmbed);
+if (!customElements.get('lite-youtube')) {
+  customElements.define('lite-youtube', LiteYTEmbed);
+}


### PR DESCRIPTION
Closes #202 

> While it is better to instantiate this right away correctly, people might attempt to add the script twice per site or even once per embed if used multiple times per page. Checking if it's already defined would silence the browser console.

I also agree with that.

Also, many design system libraries such as [shoelace](https://github.com/shoelace-style/shoelace/blob/370727c7bf70d427ad0cbb80d95df226c87dc77a/src/internal/shoelace-element.ts#L101) or [lion.js](https://github.com/search?q=repo%3Aing-bank%2Flion+customElements.get&type=code)

already use this patterns to prevent double registration of their components